### PR TITLE
Environment variables and ACL fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ When replacing the `GridFSStore` constructor with the `S3Store` one, make sure t
 ```javascript
 new S3Store({
     name, // Should be provided within buildGFS
-    isPublic: true,
-    objectACL: "public-read",
+    objectACL: "public-read", // You may not pass this property if you wish to do so
     async transformWrite(fileRecord) {
         // Either write your custom transformation code here, or re-use the one from the GridFSStore constructor
     }

--- a/src/S3Store.js
+++ b/src/S3Store.js
@@ -32,6 +32,16 @@ export default class S3Store extends StorageAdapter {
       s3Params.s3ForcePathStyle = true;
     }
 
+    if (process.env.AWS_ACCESS_KEY_ID) {
+      debug("AWS_ACCESS_KEY_ID:", process.env.AWS_ACCESS_KEY_ID)
+      s3Params.accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+    }
+
+    if (process.env.AWS_SECRET_ACCESS_KEY) {
+      debug("AWS_SECRET_ACCESS_KEY:", process.env.AWS_SECRET_ACCESS_KEY)
+      s3Params.secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+    }
+
     this.s3 = new S3({
       apiVersion: "2006-03-01",
       ...s3Params
@@ -121,7 +131,7 @@ export default class S3Store extends StorageAdapter {
 
     const uploadData = await this.s3.createMultipartUpload({
       ...opts,
-      ACL: this.objectACL
+      ...(this.objectACL ? { ACL: this.objectACL } : {})
     }).promise();
 
     debug("s3.createMultipartUpload data:", uploadData);


### PR DESCRIPTION
Fixes include:
- `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` are now being used 
- Make `objectACL` optional
- Update docs and remove `isPublic` as it's not used